### PR TITLE
Fix adding TEXT index without key length

### DIFF
--- a/db/migrate/20150901161243_add_index_to_pages.rb
+++ b/db/migrate/20150901161243_add_index_to_pages.rb
@@ -1,5 +1,5 @@
 class AddIndexToPages < ActiveRecord::Migration
   def change
-    add_index :pages, :content
+    add_index :pages, :content, length: { content: 255 }
   end
 end


### PR DESCRIPTION
インデックス作成時にエラーが出ていたものを修正
http://qiita.com/ryu-taka/items/c9045a48497c062f5595

```
DEBUG [932a8f36]    == 20150901161243 AddIndexToPages: migrating ==================================
DEBUG [932a8f36]    -- add_index(:pages, :content, {:length=>{:content=>255}})
DEBUG [932a8f36]       -> 0.0489s
DEBUG [932a8f36]    == 20150901161243 AddIndexToPages: migrated (0.0490s) =========================
DEBUG [932a8f36]    
```
