### PR TITLE
Fix the exception when cannot find search keyword in the results

### DIFF
--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -4,6 +4,10 @@ module SearchHelper
 
   def highlight_content(keyword, content)
     i = content.index(keyword)
+    if i.nil?
+      match_content = content[0..HIGHLIGHT_TRANCATE_LENGTH]
+      return "#{match_content}#{content.size > HIGHLIGHT_TRANCATE_LENGTH ? '...' : ''}"
+    end
     min_index = [i - HIGHLIGHT_TRANCATE_LENGTH, 0].max
     max_index = [i + HIGHLIGHT_TRANCATE_LENGTH, content.size - 1].min
     match_content = content[min_index..max_index]


### PR DESCRIPTION
検索したキーワードが検索結果に含まれていない時、ハイライト処理の際に例外が出ていたのを修正しました。

```
ActionView::Template::Error (undefined method `-' for nil:NilClass):
     8:       .page_result
     9:         .info
    10:           %span.title= result.title
    11:         .text= raw highlight_content(@keyword, result.content)
    12: 
    13: 
    14:   %h2= "Slackの検索結果 #{@slack_results.size}件"
  app/helpers/search_helper.rb:7:in `highlight_content'
  app/views/search/show.html.haml:11:in `block (2 levels) in _app_views_search_show_html_haml__1989315313341003616_28800440'
  app/views/search/show.html.haml:7:in `block in _app_views_search_show_html_haml__1989315313341003616_28800440'
  app/views/search/show.html.haml:6:in `_app_views_search_show_html_haml__1989315313341003616_28800440'
```
