### PR TITLE
トップページの授業情報を別ページにできるように

### DIFF
--- a/app/helpers/pages_helper.rb
+++ b/app/helpers/pages_helper.rb
@@ -22,7 +22,7 @@ module PagesHelper
 
   def term_name
     today = Date.today
-    term = 2 < today.month || today.month < 9 ? "s" : "f"
+    term = 2 < today.month || today.month < 9 ? 's' : 'f'
     "#{today.year}#{term}"
   end
 end

--- a/app/helpers/pages_helper.rb
+++ b/app/helpers/pages_helper.rb
@@ -1,6 +1,7 @@
 module PagesHelper
-  def include_page_content(path)
+  def include_page_content(path, default=nil)
     page = Page.find_by(path: path)
+    return default if page.blank?
     page.render_content
   end
 

--- a/app/helpers/pages_helper.rb
+++ b/app/helpers/pages_helper.rb
@@ -5,11 +5,24 @@ module PagesHelper
     page.render_content
   end
 
+  def include_or_create_page_content(path, message)
+    include_page_content(
+      path,
+      "<div><a href='#{edit_page_path(path)}'>#{message}</a></div>"
+    )
+  end
+
   def page_breadcrumb_links(page)
     paths = page.path.split('/')
     links = paths.map.with_index do |path, index|
       link = link_to(path, page_path(paths.take(index + 1).join('/')))
       "<div class='link'>#{link}</div>"
     end.join
+  end
+
+  def term_name
+    today = Date.today
+    term = 2 < today.month || today.month < 9 ? "s" : "f"
+    return "#{today.year}#{term}"
   end
 end

--- a/app/helpers/pages_helper.rb
+++ b/app/helpers/pages_helper.rb
@@ -23,6 +23,6 @@ module PagesHelper
   def term_name
     today = Date.today
     term = 2 < today.month || today.month < 9 ? "s" : "f"
-    return "#{today.year}#{term}"
+    "#{today.year}#{term}"
   end
 end

--- a/app/helpers/pages_helper.rb
+++ b/app/helpers/pages_helper.rb
@@ -1,5 +1,5 @@
 module PagesHelper
-  def include_page_content(path, default=nil)
+  def include_page_content(path, default = nil)
     page = Page.find_by(path: path)
     return default if page.blank?
     page.render_content

--- a/app/views/pages/edit.html.haml
+++ b/app/views/pages/edit.html.haml
@@ -1,3 +1,5 @@
+%h1= "Edit #{@page.path}"
+
 = form_for @page, url: update_page_path, method: :patch do |f|
   = f.hidden_field :path
   = f.text_field :title

--- a/app/views/pages/edit.html.haml
+++ b/app/views/pages/edit.html.haml
@@ -4,6 +4,7 @@
   = f.text_area :content, rows: 30
   = f.submit 'Save'
   = f.submit 'Draft Save', name: 'draft'
+  = link_to 'Cancel', page_path(@page.path)
 
 - if params[:draft]
   %h1= @page.title

--- a/app/views/pages/index.html.haml
+++ b/app/views/pages/index.html.haml
@@ -2,7 +2,8 @@
 
 .content-outer
   .left.content
-    = raw include_page_content('TopPage')
+    = raw include_or_create_page_content('TopPage', 'トップページをつくる')
+    = raw include_or_create_page_content(term_name, '今学期の授業情報を載せる')
 
   .right.content
     %h2


### PR DESCRIPTION
- トップをTopPageと2015fに分けて、なにもない時は作成できるようにした
  ![2015-09-02 15 01 52](https://cloud.githubusercontent.com/assets/2297122/9624067/05a258a2-5184-11e5-9af3-233045f63506.png)
- 編集画面にタイトルとキャンセルボタンをつけた
  ![edit_title](https://cloud.githubusercontent.com/assets/2297122/9624083/201576e2-5184-11e5-973b-611be1a87a85.png)
  ![cancel_button](https://cloud.githubusercontent.com/assets/2297122/9624048/e1f42d4a-5183-11e5-82ab-f406ba17422f.png)
