### PR TITLE
ナビゲーションバーの追加とレイアウト済みviewの分離

### DIFF
--- a/app/assets/stylesheets/_style.css.scss
+++ b/app/assets/stylesheets/_style.css.scss
@@ -48,19 +48,19 @@ nav {
   }
 
   .control {
-    margin-left: 20px;
     font-size: 0;
+    margin-left: 20px;
 
     a {
-      display: inline-block;
       color: $light-gray;
+      display: inline-block;
+      font-size: 1rem;
       height: $_nav_height;
       padding: 0 15px;
-      font-size: 1rem;
 
       &:hover {
-        color: $medium-gray;
         background-color: $dark-gray;
+        color: $medium-gray;
       }
     }
   }

--- a/app/assets/stylesheets/_style.css.scss
+++ b/app/assets/stylesheets/_style.css.scss
@@ -20,21 +20,53 @@ nav {
     padding: 0 10px;
   }
 
-  .title {
+  .inner-left {
     @include span-columns(1 of 2);
     height: $_nav_height;
     line-height: $_nav_height;
+
+    >div {
+      display: inline-block;
+    }
+  }
+
+  .inner-right {
+    @include span-columns(1 of 2);
+    height: $_nav_height;
+    line-height: $_nav_height;
+    text-align: right;
+
+    >div {
+      display: inline-block;
+    }
+  }
+
+  .title {
     a {
       color: white;
     }
   }
 
+  .control {
+    margin-left: 20px;
+    font-size: 0;
+
+    a {
+      display: inline-block;
+      color: $light-gray;
+      height: $_nav_height;
+      padding: 0 15px;
+      font-size: 1rem;
+
+      &:hover {
+        color: $medium-gray;
+        background-color: $dark-gray;
+      }
+    }
+  }
+
   .user {
     $_icon_size: 36px;
-    @include span-columns(1 of 2);
-    text-align: right;
-    height: $_nav_height;
-    line-height: $_nav_height;
 
     .icon {
       display: inline;

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -4,7 +4,7 @@ class PagesController < ApplicationController
   before_action :set_new_comment, only: :show
 
   def index
-    @recent_pages = Page.recent.limit(10).each
+    @pages = Page.all
   end
 
   def show

--- a/app/controllers/pre_built_pages_controller.rb
+++ b/app/controllers/pre_built_pages_controller.rb
@@ -1,0 +1,13 @@
+class PreBuiltPagesController < ApplicationController
+  before_action :require_current_user
+
+  def top
+    @recent_pages = Page.recent.limit(10).each
+  end
+
+  def wip_term
+  end
+
+  def thesis
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,5 @@
 module ApplicationHelper
+  def render_title
+    content_for?(:title) ? "#{content_for(:title)} | RG Portal" : 'RG Portal'
+  end
 end

--- a/app/helpers/pages_helper.rb
+++ b/app/helpers/pages_helper.rb
@@ -1,28 +1,9 @@
 module PagesHelper
-  def include_page_content(path, default = nil)
-    page = Page.find_by(path: path)
-    return default if page.blank?
-    page.render_content
-  end
-
-  def include_or_create_page_content(path, message)
-    include_page_content(
-      path,
-      "<div><a href='#{edit_page_path(path)}'>#{message}</a></div>"
-    )
-  end
-
   def page_breadcrumb_links(page)
     paths = page.path.split('/')
     links = paths.map.with_index do |path, index|
       link = link_to(path, page_path(paths.take(index + 1).join('/')))
       "<div class='link'>#{link}</div>"
     end.join
-  end
-
-  def term_name
-    today = Date.today
-    term = 2 < today.month || today.month < 9 ? 's' : 'f'
-    "#{today.year}#{term}"
   end
 end

--- a/app/helpers/pre_built_pages_controller_helper.rb
+++ b/app/helpers/pre_built_pages_controller_helper.rb
@@ -1,0 +1,20 @@
+module PreBuiltPagesControllerHelper
+  def include_page_content(path, default = nil)
+    page = Page.find_by(path: path)
+    return default if page.blank?
+    page.render_content
+  end
+
+  def include_or_create_page_content(path, message)
+    include_page_content(
+      path,
+      "<div><a href='#{edit_page_path(path)}'>#{message}</a></div>"
+    )
+  end
+
+  def term_name
+    today = Date.today
+    term = 2 < today.month || today.month < 9 ? 's' : 'f'
+    "#{today.year}#{term}"
+  end
+end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -2,7 +2,7 @@
 %html{ lang: 'ja' }
   %head
     %meta{ charset: 'utf-8' }
-    %title= content_for?(:title) ? "#{content_for(:title)} | RG Portal" : 'RG Portal'
+    %title= render_title
     = content_for(:css)
     = stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track' => true
     = content_for(:javascript)

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -11,12 +11,17 @@
   %body
     %nav
       .inner
-        .title
-          = link_to 'RG Portal', root_path
+        .inner-left
+          .title
+            = link_to 'RG Portal', root_path
+          .control
+            = link_to 'WIP/TERM', '#'
+            = link_to 'Thesis', '#'
         - if @current_user
-          .user
-            .icon= image_tag @current_user.icon_url
-            .name= @current_user.nickname
+          .inner-right
+            .user
+              .icon= image_tag @current_user.icon_url
+              .name= @current_user.nickname
 
     - if content_for?(:header)
       .header

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -2,7 +2,7 @@
 %html{ lang: 'ja' }
   %head
     %meta{ charset: 'utf-8' }
-    %title= content_for?(:title) ? content_for(:title) : 'RG Portal'
+    %title= content_for?(:title) ? "#{content_for(:title)} | RG Portal" : 'RG Portal'
     = content_for(:css)
     = stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track' => true
     = content_for(:javascript)
@@ -15,8 +15,8 @@
           .title
             = link_to 'RG Portal', root_path
           .control
-            = link_to 'WIP/TERM', '#'
-            = link_to 'Thesis', '#'
+            = link_to 'WIP/TERM', wip_term_path
+            = link_to 'Thesis', thesis_path
         - if @current_user
           .inner-right
             .user

--- a/app/views/pages/index.html.haml
+++ b/app/views/pages/index.html.haml
@@ -1,14 +1,8 @@
 = render 'search/search_bar'
 
+%h1
+  ページ一覧
 .content-outer
-  .left.content
-    = raw include_or_create_page_content('TopPage', 'トップページをつくる')
-    = raw include_or_create_page_content(term_name, '今学期の授業情報を載せる')
-
-  .right.content
-    %h2
-      新しく作られたページ
-
-    %ul
-      - @recent_pages.each do |page|
-        %li= link_to page.title, page_path(path: page.path)
+  %ul
+    - @pages.each do |page|
+      %li= link_to page.title, page_path(path: page.path)

--- a/app/views/pre_built_pages/thesis.html.haml
+++ b/app/views/pre_built_pages/thesis.html.haml
@@ -1,0 +1,5 @@
+- content_for :title, 'Thesis'
+
+.content-outer
+  = raw include_or_create_page_content('Thesis', '卒論の説明をつくる')
+  = raw include_or_create_page_content("#{term_name}/Thesis", '今学期の卒論情報を載せる')

--- a/app/views/pre_built_pages/top.html.haml
+++ b/app/views/pre_built_pages/top.html.haml
@@ -1,0 +1,14 @@
+= render 'search/search_bar'
+
+.content-outer
+  .left.content
+    = raw include_or_create_page_content('TopPage', 'トップページをつくる')
+    = raw include_or_create_page_content("#{term_name}/TopPage", '今学期の授業情報を載せる')
+
+  .right.content
+    %h2
+      新しく作られたページ
+
+    %ul
+      - @recent_pages.each do |page|
+        %li= link_to page.title, page_path(path: page.path)

--- a/app/views/pre_built_pages/wip_term.html.haml
+++ b/app/views/pre_built_pages/wip_term.html.haml
@@ -1,0 +1,5 @@
+- content_for :title, 'WIP/TERM'
+
+.content-outer
+  = raw include_or_create_page_content('WipTerm', 'WIP/TERMの説明をつくる')
+  = raw include_or_create_page_content("#{term_name}/WipTerm", '今学期のWIP/TERM情報を載せる')

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,10 +6,10 @@ Rails.application.routes.draw do
   get '/thesis' => 'pre_built_pages#thesis'
 
   scope :pages do
-    get   '/' => 'pages#index', as: :pages
-    get   '*path/edit' => 'pages#edit', as: :edit_page
+    get '/' => 'pages#index', as: :pages
+    get '*path/edit' => 'pages#edit', as: :edit_page
     patch '*path' => 'pages#update', as: :update_page
-    get   '*path' => 'pages#show', as: :page
+    get '*path' => 'pages#show', as: :page
   end
 
   resources :comments, only: :create

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,12 @@
 Rails.application.routes.draw do
   get '/auth/slack/callback' => 'session#slack_callback'
 
-  root 'pages#index'
+  root 'pre_built_pages#top'
+  get '/wip_term' => 'pre_built_pages#wip_term'
+  get '/thesis' => 'pre_built_pages#thesis'
+
   scope :pages do
+    get   '/' => 'pages#index', as: :pages
     get   '*path/edit' => 'pages#edit', as: :edit_page
     patch '*path' => 'pages#update', as: :update_page
     get   '*path' => 'pages#show', as: :page

--- a/spec/controllers/likes_controller_spec.rb
+++ b/spec/controllers/likes_controller_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
 
 RSpec.describe LikesController, type: :controller do
-
 end

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
 
 RSpec.describe PagesController, type: :controller do
-
 end

--- a/spec/controllers/pre_built_pages_controller_spec.rb
+++ b/spec/controllers/pre_built_pages_controller_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
 
 RSpec.describe PreBuiltPagesController, type: :controller do
-
 end

--- a/spec/controllers/pre_built_pages_controller_spec.rb
+++ b/spec/controllers/pre_built_pages_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe PreBuiltPagesController, type: :controller do
+
+end

--- a/spec/controllers/session_controller_spec.rb
+++ b/spec/controllers/session_controller_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
 
 RSpec.describe SessionController, type: :controller do
-
 end

--- a/spec/helpers/pre_built_pages_controller_helper_spec.rb
+++ b/spec/helpers/pre_built_pages_controller_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the PreBuiltPagesControllerHelper. For example:
+#
+# describe PreBuiltPagesControllerHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe PreBuiltPagesControllerHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
To close #13 

こんな感じでナビゲーションバーを付けました。
"Thesis"のとこが暗くなってるのは、hoverした時の挙動です。
![2015-09-03 18 52 37](https://cloud.githubusercontent.com/assets/2297122/9655601/3f6d3860-526d-11e5-821b-f7906f67a2f8.png)

なお、他のページが増えることによる名前付けの都合から、トップページに表示する授業情報のページのパスを`/pages/2015f/TopPage`の形に変えました。

![2015-09-03 18 53 05](https://cloud.githubusercontent.com/assets/2297122/9655606/59c36266-526d-11e5-9aea-d5df20490f38.png)
WIP/TERMおよび卒論ページはトップページと同じようにずっと変わらないものを`/pages/WipTerm`、その学期限定の情報を`/pages/2015f/WipTerm`という形式のページに書く想定です。

増やしたページのアクションをPagesControllerに入れるのは微妙な感じがしたので、PreBuiltPagesControllerを作って、トップページも含めたレイアウト済みのviewは全てそのコントローラーでサーブするようにしました。
