### PR TITLE
Add border-collapse style on content table

### DIFF
--- a/app/assets/stylesheets/_content.css.scss
+++ b/app/assets/stylesheets/_content.css.scss
@@ -58,4 +58,8 @@
     margin-bottom: 20px;
     padding: 0 $_content_padding;
   }
+
+  table {
+    border-collapse: separate;
+  }
 }


### PR DESCRIPTION
テーブルタグのマージンがおかしい問題を解決しました。
<img width="30" alt="screenshot 2015-10-23 16 50 22" src="https://cloud.githubusercontent.com/assets/720609/10687203/3095524a-79a6-11e5-9775-7ece09ca0da1.png">
