### PR TITLE
複合ページに各ページヘの編集リンクを表示

### DIFF
--- a/app/assets/stylesheets/pages.css.scss
+++ b/app/assets/stylesheets/pages.css.scss
@@ -144,6 +144,25 @@
   margin-bottom: 10px;
 }
 
+.content .edit_link {
+  font-size: 60%;
+  padding: 0;
+  text-align: right;
+  width: 100%;
+
+  a {
+    border: solid 1px lightgray;
+    border-radius: 3px;
+    color: gray;
+    padding: 5px 10px;
+
+    &:hover {
+      border-color: gray;
+      color: black;
+    }
+  }
+}
+
 .pages.edit {
   .action_link {
     margin-left: 10px;

--- a/app/helpers/pre_built_pages_helper.rb
+++ b/app/helpers/pre_built_pages_helper.rb
@@ -1,8 +1,8 @@
 module PreBuiltPagesHelper
   def include_or_create_page_content(path, message, options = {})
-    options.reverse_merge!({
+    options.reverse_merge!(
       edit_link: true
-    })
+    )
 
     page = Page.find_by(path: path)
     return "<div><a href='#{edit_page_path(path)}'>#{message}</a></div>" if page.blank?

--- a/app/helpers/pre_built_pages_helper.rb
+++ b/app/helpers/pre_built_pages_helper.rb
@@ -1,14 +1,15 @@
 module PreBuiltPagesHelper
-  def include_page_content(path, default = nil)
+  def include_page_content(path, default = nil, postfix = "")
     page = Page.find_by(path: path)
     return default if page.blank?
-    page.render_content
+    page.render_content + postfix
   end
 
-  def include_or_create_page_content(path, message)
+  def include_or_create_page_content(path, message, options = {})
     include_page_content(
       path,
-      "<div><a href='#{edit_page_path(path)}'>#{message}</a></div>"
+      "<div><a href='#{edit_page_path(path)}'>#{message}</a></div>",
+      options[:edit_link] ? "<div class=edit_link><a href='#{edit_page_path(path)}'>このページを編集</a></div>" : ""
     )
   end
 

--- a/app/helpers/pre_built_pages_helper.rb
+++ b/app/helpers/pre_built_pages_helper.rb
@@ -1,16 +1,13 @@
 module PreBuiltPagesHelper
-  def include_page_content(path, default = nil, postfix = '')
-    page = Page.find_by(path: path)
-    return default if page.blank?
-    page.render_content + postfix
-  end
-
   def include_or_create_page_content(path, message, options = {})
-    include_page_content(
-      path,
-      "<div><a href='#{edit_page_path(path)}'>#{message}</a></div>",
-      options[:edit_link] ? "<div class=edit_link><a href='#{edit_page_path(path)}'>このページを編集</a></div>" : ''
-    )
+    options.reverse_merge!({
+      edit_link: true
+    })
+
+    page = Page.find_by(path: path)
+    return "<div><a href='#{edit_page_path(path)}'>#{message}</a></div>" if page.blank?
+    edit_button = options[:edit_link] ? "<div class=edit_link><a href='#{edit_page_path(path)}'>このページを編集</a></div>" : ''
+    page.render_content + edit_button
   end
 
   def term_name

--- a/app/helpers/pre_built_pages_helper.rb
+++ b/app/helpers/pre_built_pages_helper.rb
@@ -1,5 +1,5 @@
 module PreBuiltPagesHelper
-  def include_page_content(path, default = nil, postfix = "")
+  def include_page_content(path, default = nil, postfix = '')
     page = Page.find_by(path: path)
     return default if page.blank?
     page.render_content + postfix
@@ -9,7 +9,7 @@ module PreBuiltPagesHelper
     include_page_content(
       path,
       "<div><a href='#{edit_page_path(path)}'>#{message}</a></div>",
-      options[:edit_link] ? "<div class=edit_link><a href='#{edit_page_path(path)}'>このページを編集</a></div>" : ""
+      options[:edit_link] ? "<div class=edit_link><a href='#{edit_page_path(path)}'>このページを編集</a></div>" : ''
     )
   end
 

--- a/app/views/comments/_list.html.haml
+++ b/app/views/comments/_list.html.haml
@@ -10,7 +10,7 @@
       .box
         .info
           .nickname= comment.user.nickname
-        .content= raw comment.render_content
+        .content= comment.render_content.html_safe
 
   = form_for Comment.new(page: page) do |f|
     = f.hidden_field :page_id

--- a/app/views/page_histories/show.html.haml
+++ b/app/views/page_histories/show.html.haml
@@ -9,4 +9,4 @@
   %h2 Title
   %p= @history.title
   %h2 Content
-  = raw @history.render_content
+  = @history.render_content.html_safe

--- a/app/views/pages/_page.html.haml
+++ b/app/views/pages/_page.html.haml
@@ -11,10 +11,10 @@
       = link_to page_histories_path do
         %i.fa.fa-history
         = page.histories.count
-  .breadcrumb= raw page_breadcrumb_links(page)
+  .breadcrumb= page_breadcrumb_links(page).html_safe
 
 .content
-  = raw page.render_content
+  = page.render_content.html_safe
 
   - if page.subpages.present?
     %h1 Subpages

--- a/app/views/pages/index.html.haml
+++ b/app/views/pages/index.html.haml
@@ -2,8 +2,8 @@
 
 .content-outer
   .left.content
-    = raw include_or_create_page_content('TopPage', 'トップページをつくる', edit_link: true)
-    = raw include_or_create_page_content(term_name, '今学期の授業情報を載せる', edit_link: true)
+    = raw include_or_create_page_content('TopPage', 'トップページをつくる')
+    = raw include_or_create_page_content(term_name, '今学期の授業情報を載せる')
 
   .right.content
     %h2

--- a/app/views/pages/index.html.haml
+++ b/app/views/pages/index.html.haml
@@ -2,8 +2,8 @@
 
 .content-outer
   .left.content
-    = raw include_or_create_page_content('TopPage', 'トップページをつくる')
-    = raw include_or_create_page_content(term_name, '今学期の授業情報を載せる')
+    = raw include_or_create_page_content('TopPage', 'トップページをつくる', edit_link: true)
+    = raw include_or_create_page_content(term_name, '今学期の授業情報を載せる', edit_link: true)
 
   .right.content
     %h2

--- a/app/views/pages/index.html.haml
+++ b/app/views/pages/index.html.haml
@@ -2,8 +2,8 @@
 
 .content-outer
   .left.content
-    = raw include_or_create_page_content('TopPage', 'トップページをつくる')
-    = raw include_or_create_page_content(term_name, '今学期の授業情報を載せる')
+    = include_or_create_page_content('TopPage', 'トップページをつくる').html_safe
+    = include_or_create_page_content(term_name, '今学期の授業情報を載せる').html_safe
 
   .right.content
     %h2

--- a/app/views/pre_built_pages/newcomer.html.haml
+++ b/app/views/pre_built_pages/newcomer.html.haml
@@ -2,4 +2,4 @@
 
 .content-outer
   .content
-    = raw include_or_create_page_content('Newcomer', '新人向けの説明をつくる')
+    = raw include_or_create_page_content('Newcomer', '新人向けの説明をつくる', edit_link: true)

--- a/app/views/pre_built_pages/newcomer.html.haml
+++ b/app/views/pre_built_pages/newcomer.html.haml
@@ -2,4 +2,4 @@
 
 .content-outer
   .content
-    = raw include_or_create_page_content('Newcomer', '新人向けの説明をつくる')
+    = include_or_create_page_content('Newcomer', '新人向けの説明をつくる').html_safe

--- a/app/views/pre_built_pages/newcomer.html.haml
+++ b/app/views/pre_built_pages/newcomer.html.haml
@@ -2,4 +2,4 @@
 
 .content-outer
   .content
-    = raw include_or_create_page_content('Newcomer', '新人向けの説明をつくる', edit_link: true)
+    = raw include_or_create_page_content('Newcomer', '新人向けの説明をつくる')

--- a/app/views/pre_built_pages/thesis.html.haml
+++ b/app/views/pre_built_pages/thesis.html.haml
@@ -2,5 +2,5 @@
 
 .content-outer
   .content
-    = raw include_or_create_page_content('Thesis', '卒論の説明をつくる')
-    = raw include_or_create_page_content("#{term_name}/Thesis", '今学期の卒論情報を載せる')
+    = include_or_create_page_content('Thesis', '卒論の説明をつくる').html_safe
+    = include_or_create_page_content("#{term_name}/Thesis", '今学期の卒論情報を載せる').html_safe

--- a/app/views/pre_built_pages/thesis.html.haml
+++ b/app/views/pre_built_pages/thesis.html.haml
@@ -2,5 +2,5 @@
 
 .content-outer
   .content
-    = raw include_or_create_page_content('Thesis', '卒論の説明をつくる', edit_link: true)
-    = raw include_or_create_page_content("#{term_name}/Thesis", '今学期の卒論情報を載せる', edit_link: true)
+    = raw include_or_create_page_content('Thesis', '卒論の説明をつくる')
+    = raw include_or_create_page_content("#{term_name}/Thesis", '今学期の卒論情報を載せる')

--- a/app/views/pre_built_pages/thesis.html.haml
+++ b/app/views/pre_built_pages/thesis.html.haml
@@ -2,5 +2,5 @@
 
 .content-outer
   .content
-    = raw include_or_create_page_content('Thesis', '卒論の説明をつくる')
-    = raw include_or_create_page_content("#{term_name}/Thesis", '今学期の卒論情報を載せる')
+    = raw include_or_create_page_content('Thesis', '卒論の説明をつくる', edit_link: true)
+    = raw include_or_create_page_content("#{term_name}/Thesis", '今学期の卒論情報を載せる', edit_link: true)

--- a/app/views/pre_built_pages/wip_term.html.haml
+++ b/app/views/pre_built_pages/wip_term.html.haml
@@ -2,6 +2,5 @@
 
 .content-outer
   .content
-    = raw include_or_create_page_content('WipTerm', 'WIP/TERMの説明をつくる')
-    = raw include_or_create_page_content("#{term_name}/WipTerm",
-                                         '今学期のWIP/TERM情報を載せる')
+    = include_or_create_page_content('WipTerm', 'WIP/TERMの説明をつくる').html_safe
+    = include_or_create_page_content("#{term_name}/WipTerm", '今学期のWIP/TERM情報を載せる').html_safe

--- a/app/views/pre_built_pages/wip_term.html.haml
+++ b/app/views/pre_built_pages/wip_term.html.haml
@@ -2,6 +2,7 @@
 
 .content-outer
   .content
-    = raw include_or_create_page_content('WipTerm', 'WIP/TERMの説明をつくる')
+    = raw include_or_create_page_content('WipTerm', 'WIP/TERMの説明をつくる', edit_link: true)
     = raw include_or_create_page_content("#{term_name}/WipTerm",
-                                         '今学期のWIP/TERM情報を載せる')
+                                         '今学期のWIP/TERM情報を載せる',
+                                         edit_link: true)

--- a/app/views/pre_built_pages/wip_term.html.haml
+++ b/app/views/pre_built_pages/wip_term.html.haml
@@ -2,7 +2,6 @@
 
 .content-outer
   .content
-    = raw include_or_create_page_content('WipTerm', 'WIP/TERMの説明をつくる', edit_link: true)
+    = raw include_or_create_page_content('WipTerm', 'WIP/TERMの説明をつくる')
     = raw include_or_create_page_content("#{term_name}/WipTerm",
-                                         '今学期のWIP/TERM情報を載せる',
-                                         edit_link: true)
+                                         '今学期のWIP/TERM情報を載せる')

--- a/app/views/search/show.html.haml
+++ b/app/views/search/show.html.haml
@@ -8,7 +8,7 @@
       .page_result
         .info
           %span.title= result.title
-        .text= raw highlight_content(@keyword, result.content)
+        .text= highlight_content(@keyword, result.content).html_safe
 
 
   %h2= "Slackの検索結果 #{@slack_results.size}件"

--- a/spec/helpers/pre_built_pages_helper_spec.rb
+++ b/spec/helpers/pre_built_pages_helper_spec.rb
@@ -1,34 +1,23 @@
 require 'rails_helper'
 
 RSpec.describe PreBuiltPagesHelper, type: :helper do
-  describe '#include_page_content' do
-    let(:page) { FactoryGirl.create(:page) }
-    let(:default) { nil }
-    subject { helper.include_page_content(page.path, default) }
-
-    context 'when given exists page path' do
-      it 'returns rendered content' do
-        is_expected.to eq(page.render_content)
-      end
-    end
-
-    context 'when given not exists page path' do
-      before { page.destroy }
-
-      it 'returns default' do
-        is_expected.to eq(default)
-      end
-    end
-  end
-
   describe '#include_or_create_page_content' do
     let(:page) { FactoryGirl.create(:page) }
     let(:message) { 'message' }
     subject { helper.include_or_create_page_content(page.path, message) }
 
     context 'when given exists page path' do
-      it 'returns rendered content' do
-        is_expected.to eq(page.render_content)
+      it 'returns rendered content with edit button' do
+        is_expected.to include(page.render_content)
+        is_expected.to include('class=edit_link')
+      end
+
+      context 'without edit button' do
+        let(:options) { { edit_link: false } }
+        subject { helper.include_or_create_page_content(page.path, message, options) }
+        it 'returns rendered content only' do
+          is_expected.to eq(page.render_content)
+        end
       end
     end
 


### PR DESCRIPTION
pages#indexやpre_built_pagesの各viewで下画像赤枠のようにそのページを編集するリンクを表示する

![2015-10-24 1 23 34](https://cloud.githubusercontent.com/assets/2297122/10698858/18c66da0-79ee-11e5-8319-dd09c194b903.png)
