### PR TITLE
Add responsive style for smartphone

### DIFF
--- a/app/assets/stylesheets/_responsive.css.scss
+++ b/app/assets/stylesheets/_responsive.css.scss
@@ -1,0 +1,29 @@
+@media screen and (max-width: 640px) {
+  nav {
+    padding: 0 5px;
+  }
+
+  nav .inner-left {
+    @include span-columns(3 of 5);
+
+    .control {
+      display: none;
+    }
+  }
+
+  nav .inner-right {
+    @include span-columns(2 of 5);
+
+    .user .name {
+      display: none;
+    }
+  }
+
+  .main {
+    padding: 10px;
+  }
+
+  .left.content, .right.content {
+    @include span-columns(12);
+  }
+}

--- a/app/assets/stylesheets/_responsive.css.scss
+++ b/app/assets/stylesheets/_responsive.css.scss
@@ -23,7 +23,8 @@
     padding: 10px;
   }
 
-  .left.content, .right.content {
+  .left.content,
+  .right.content {
     @include span-columns(12);
   }
 }

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -24,6 +24,7 @@
 @import "search";
 @import "settings";
 @import "users";
+@import "responsive";
 
 .flash {
   margin: 0 10px 20px;

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -3,6 +3,7 @@
   %head
     %meta{ charset: 'utf-8' }
     %title= render_title
+    %meta{ name: 'viewport', content: 'width=device-width, initial-scale=1.0' }
     = content_for(:css)
     = stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track' => true
     = content_for(:javascript)


### PR DESCRIPTION
スマホでも見やすいよう、レスポンシブスタイルを定義しました。
一部メニュー等が非表示になっています。

![2015-10-27 10 19 05](https://cloud.githubusercontent.com/assets/720609/10747055/494106fe-7c94-11e5-981d-d637222284f6.png)
![2015-10-27 10 19 12](https://cloud.githubusercontent.com/assets/720609/10747056/49415fdc-7c94-11e5-8de3-37d18fcbd654.png)
