### PR TITLE
ナビゲーションバーのレスポンシブ対応と細かいビュー修正

### DIFF
--- a/app/assets/javascripts/responsive.js.coffee
+++ b/app/assets/javascripts/responsive.js.coffee
@@ -1,0 +1,4 @@
+jQuery ($) ->
+  $control = $('.control')
+  $('.mobile-control').on 'click', ->
+    $control.toggleClass('shown')

--- a/app/assets/stylesheets/_responsive.css.scss
+++ b/app/assets/stylesheets/_responsive.css.scss
@@ -1,4 +1,4 @@
-@media screen and (max-width: 640px) {
+@media screen and (max-width: 800px) {
   nav {
     padding: 0 5px;
   }

--- a/app/assets/stylesheets/_responsive.css.scss
+++ b/app/assets/stylesheets/_responsive.css.scss
@@ -6,8 +6,34 @@
   nav .inner-left {
     @include span-columns(3 of 5);
 
+    .mobile-control {
+      cursor: pointer;
+      display: inline-block;
+      padding-right: 10px;
+    }
+
     .control {
-      display: none;
+      background-color: #3c3c3c;
+      bottom: 100%;
+      left: 0;
+      margin: 0;
+      position: absolute;
+      width: 100%;
+      z-index: 1;
+      opacity: 0;
+      transition: opacity 0.5s ease-in-out;
+
+      &.shown {
+        opacity: 1;
+        bottom: auto;
+        top: $nav_height;
+      }
+
+      a {
+        display: block;
+        border-top: 1px solid $light-gray;
+        padding-left: 20px;
+      }
     }
   }
 

--- a/app/assets/stylesheets/_responsive.css.scss
+++ b/app/assets/stylesheets/_responsive.css.scss
@@ -17,21 +17,21 @@
       bottom: 100%;
       left: 0;
       margin: 0;
+      opacity: 0;
       position: absolute;
+      transition: opacity 0.5s ease-in-out;
       width: 100%;
       z-index: 1;
-      opacity: 0;
-      transition: opacity 0.5s ease-in-out;
 
       &.shown {
-        opacity: 1;
         bottom: auto;
+        opacity: 1;
         top: $nav_height;
       }
 
       a {
-        display: block;
         border-top: 1px solid $light-gray;
+        display: block;
         padding-left: 20px;
       }
     }

--- a/app/assets/stylesheets/_size.scss
+++ b/app/assets/stylesheets/_size.scss
@@ -1,0 +1,2 @@
+$nav_height: 50px;
+$icon_size: 36px;

--- a/app/assets/stylesheets/_style.css.scss
+++ b/app/assets/stylesheets/_style.css.scss
@@ -9,8 +9,7 @@ nav > .inner,
 }
 
 nav {
-  $_nav_height: 50px;
-  height: $_nav_height;
+  height: $nav_height;
   padding: 0 30px;
   color: white;
   background-color: #3c3c3c;
@@ -22,18 +21,22 @@ nav {
 
   .inner-left {
     @include span-columns(3 of 4);
-    height: $_nav_height;
-    line-height: $_nav_height;
+    height: $nav_height;
+    line-height: $nav_height;
 
     >div {
       display: inline-block;
+    }
+
+    .mobile-control {
+      display: none;
     }
   }
 
   .inner-right {
     @include span-columns(1 of 4);
-    height: $_nav_height;
-    line-height: $_nav_height;
+    height: $nav_height;
+    line-height: $nav_height;
     text-align: right;
 
     >div {
@@ -55,7 +58,7 @@ nav {
       color: $light-gray;
       display: inline-block;
       font-size: 1rem;
-      height: $_nav_height;
+      height: $nav_height;
       padding: 0 15px;
 
       &:hover {
@@ -66,17 +69,15 @@ nav {
   }
 
   .user {
-    $_icon_size: 36px;
-
     .icon {
       display: inline;
 
       img {
-        margin-top: ($_nav_height - $_icon_size) / 2;
+        margin-top: ($nav_height - $icon_size) / 2;
         margin-right: 5px;
         border-radius: 3px;
-        width: $_icon_size;
-        height: $_icon_size;
+        width: $icon_size;
+        height: $icon_size;
       }
     }
 

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -16,6 +16,7 @@
 
 // Customize
 @import "color";
+@import "size";
 @import "content";
 @import "style";
 

--- a/app/controllers/meetings_controller.rb
+++ b/app/controllers/meetings_controller.rb
@@ -5,7 +5,7 @@ class MeetingsController < ApplicationController
   before_action :set_emoji_completion, only: [:new, :edit]
 
   def index
-    @meetings = Meeting.order(created_at: :desc).page(params[:page]).per(10)
+    @meetings = Meeting.order(start_at: :desc).page(params[:page]).per(10)
   end
 
   def show

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -9,7 +9,7 @@ class PagesController < ApplicationController
   NUM_OF_RECENT_PAGES = 30
 
   def index
-    @recent_pages = Page.recent.limit(NUM_OF_RECENT_PAGES)
+    @recent_pages = Page.order(updated_at: :desc).limit(NUM_OF_RECENT_PAGES)
   end
 
   def show

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -6,7 +6,6 @@ class Page < ActiveRecord::Base
   has_many :comments, class_name: 'PageComment'
   has_many :likes
   has_many :histories, class_name: PageHistory
-  scope :recent, -> { order('pages.created_at DESC') }
 
   validates :path, presence: true, uniqueness: true
   validates :content, presence: true

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -13,6 +13,8 @@
     %nav
       .inner
         .inner-left
+          .mobile-control
+            %i.fa.fa-bars
           .title
             = link_to 'RG Portal（仮）', root_path
           .control

--- a/app/views/meetings/index.html.haml
+++ b/app/views/meetings/index.html.haml
@@ -2,14 +2,12 @@
   %h1 ミーティング一覧
   %table
     %tr
-      %th #
       %th Name
       %th Start At
       %th End At
       %th Attendance Count
     - @meetings.each do |meeting|
       %tr
-        %td= meeting.id
         %td= link_to meeting.name, meeting_path(meeting)
         %td= meeting.start_at.strftime('%Y/%m/%d %H:%M')
         %td= meeting.end_at.strftime('%Y/%m/%d %H:%M')

--- a/app/views/pages/index.html.haml
+++ b/app/views/pages/index.html.haml
@@ -7,7 +7,7 @@
 
   .right.content
     %h2
-      新しく作られたページ
+      最近更新されたページ
 
     %ul
       - @recent_pages.each do |page|


### PR DESCRIPTION
### ナビゲーションバーのレスポンシブ対応

iPhoneやたて向きのiPadでナビゲーションバーのコンテンツを表示できるボタンを追加しました。
3つのバーのアイコンをタップすると、opacityのアニメーション付きでメニューをトグルできます。
![2015-11-04 18 22 42](https://cloud.githubusercontent.com/assets/2297122/10934153/63f91f5c-8321-11e5-85fb-9de1c91a8a61.png)
![2015-11-04 18 23 00](https://cloud.githubusercontent.com/assets/2297122/10934156/67d7c43e-8321-11e5-8aea-13edff55ab28.png)
### 細かいビュー修正
- ミーティング一覧で表示されていたIDはユーザに見せる必要のない項目なので、削除しました
- ミーティング一覧における表示順を追加した順でなくstart_atの降順に変更しました
- トップページに表示するページの一覧を最近作成されたページではなく、最近**更新**されたページにしました
