### PR TITLE
Store Slack access token on create session

### DIFF
--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -25,6 +25,8 @@ class SessionController < ApplicationController
         slack_credential.user
       end
 
+    slack_credential.update(access_token: auth.credentials.token)
+
     session[:user_id] = user.id
     load_forwarding_url root_path
   end

--- a/db/migrate/20151202082349_add_access_token_to_slack_credentials.rb
+++ b/db/migrate/20151202082349_add_access_token_to_slack_credentials.rb
@@ -1,0 +1,5 @@
+class AddAccessTokenToSlackCredentials < ActiveRecord::Migration
+  def change
+    add_column :slack_credentials, :access_token, :string, after: :slack_user_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151129164519) do
+ActiveRecord::Schema.define(version: 20151202082349) do
 
   create_table "api_keys", force: :cascade do |t|
     t.integer  "user_id"
@@ -165,6 +165,7 @@ ActiveRecord::Schema.define(version: 20151129164519) do
     t.string   "slack_user_id"
     t.datetime "created_at",    null: false
     t.datetime "updated_at",    null: false
+    t.string   "access_token"
   end
 
   add_index "slack_credentials", ["user_id"], name: "index_slack_credentials_on_user_id"


### PR DESCRIPTION
https://github.com/sfc-rg/rg-portal/issues/39 をするためにSlackのAccess Tokenを認証時に保存するようにします。

@sfc-rg/reviewer レビューお願いします
