### PR TITLE
Change client_max_body_size to 20MB

### DIFF
--- a/cookbook/nginx/templates/nginx.conf.erb
+++ b/cookbook/nginx/templates/nginx.conf.erb
@@ -36,7 +36,7 @@ http {
 
     root /var/www/<%= node['nginx']['name'] %>/current/public;
     error_page 500 502 503 504 /500.html;
-    client_max_body_size 3M;
+    client_max_body_size 20M;
 
     location / {
       try_files $uri @application;


### PR DESCRIPTION
[FYI] nginxでのアップロードファイルの制限を20MBに引き上げました、すでに反映済みなのでこのままマージします
