### PR TITLE
細かいビュー周りの修正

### DIFF
--- a/app/controllers/meetings_controller.rb
+++ b/app/controllers/meetings_controller.rb
@@ -3,7 +3,7 @@ class MeetingsController < ApplicationController
   include UserComplete
   before_action :require_active_current_user
   before_action :require_privilege, only: [:update]
-  before_action :set_meeting, only: [:show, :edit, :update]
+  before_action :set_meeting, only: [:edit, :update]
   before_action :set_emoji_completion, only: [:new, :edit]
   before_action :set_user_completion, only: [:new, :edit]
 
@@ -12,6 +12,7 @@ class MeetingsController < ApplicationController
   end
 
   def show
+    @meeting = Meeting.includes(presentations: [:user, :handouts]).find(params[:id])
   end
 
   def new

--- a/app/models/meeting.rb
+++ b/app/models/meeting.rb
@@ -3,7 +3,6 @@ class Meeting < ActiveRecord::Base
   include MarkdownRender
 
   has_many :meeting_attendances, dependent: :destroy
-  has_many :attendances, through: :meeting_attendances, source: :user
   has_many :presentations
 
   validates :name, presence: true

--- a/app/models/meeting_attendance.rb
+++ b/app/models/meeting_attendance.rb
@@ -1,5 +1,5 @@
 class MeetingAttendance < ActiveRecord::Base
-  belongs_to :meeting
+  belongs_to :meeting, counter_cache: true
   belongs_to :user
 
   validates :meeting, presence: true

--- a/app/views/comments/_new.html.haml
+++ b/app/views/comments/_new.html.haml
@@ -5,5 +5,6 @@
     .user
       .icon= image_tag @current_user.icon_url
     .box
-      = f.text_area :content, rows: 4, class: 'emoji-complete user-complete'
+      = f.text_area :content, rows: 4, class: 'emoji-complete user-complete',
+        placeholder: 'Let\'s type :smile: and use emojis in your comment!'
       = f.submit 'Comment'

--- a/app/views/groups/index.html.haml
+++ b/app/views/groups/index.html.haml
@@ -11,7 +11,7 @@
         %td= group.id
         %td= group.kind.to_s
         %td= group.name
-        %td= group.users.count
+        %td= group.users.size
 
   %h1 グループ追加
   = form_for Group.new do |f|

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -16,7 +16,7 @@
           .mobile-control
             %i.fa.fa-bars
           .title
-            = link_to 'RG Portal（仮）', root_path
+            = link_to 'RG Portal', root_path
           .control
             = link_to 'WIP/TERM', wip_term_path
             = link_to 'Thesis', thesis_path

--- a/app/views/meetings/index.html.haml
+++ b/app/views/meetings/index.html.haml
@@ -11,6 +11,6 @@
         %td= link_to meeting.name, meeting_path(meeting)
         %td= meeting.start_at.strftime('%Y/%m/%d %H:%M')
         %td= meeting.end_at.strftime('%Y/%m/%d %H:%M')
-        %td= meeting.attendances.count
+        %td= meeting.meeting_attendances.size
   = paginate @meetings
   = link_to 'ミーティング追加', new_meeting_path

--- a/app/views/meetings/show.html.haml
+++ b/app/views/meetings/show.html.haml
@@ -10,7 +10,7 @@
     = @meeting.end_at.strftime('%Y/%m/%d %H:%M')
   %p
     現在の出席者数:
-    = @meeting.attendances.count
+    = @meeting.meeting_attendances.size
   - if @meeting.presentations.any?
     %p
       プレゼンテーション登録者数:

--- a/app/views/meetings/show.html.haml
+++ b/app/views/meetings/show.html.haml
@@ -14,7 +14,7 @@
   - if @meeting.presentations.any?
     %p
       プレゼンテーション登録者数:
-      = @meeting.presentations.count
+      = @meeting.presentations.size
   - if @meeting.content
     = @meeting.render_content.html_safe
   %h2 登録プレゼンテーション一覧

--- a/app/views/meetings/show.html.haml
+++ b/app/views/meetings/show.html.haml
@@ -11,6 +11,10 @@
   %p
     現在の出席者数:
     = @meeting.attendances.count
+  - if @meeting.presentations.any?
+    %p
+      プレゼンテーション登録者数:
+      = @meeting.presentations.count
   - if @meeting.content
     = @meeting.render_content.html_safe
   %h2 登録プレゼンテーション一覧

--- a/app/views/pages/_page.html.haml
+++ b/app/views/pages/_page.html.haml
@@ -6,11 +6,11 @@
         %i.fa.fa-edit
     %span.star
       %i.fa.fa-star
-      = page.likes.count
+      = page.likes.size
     %span.history
       = link_to page_histories_path do
         %i.fa.fa-history
-        = page.histories.count
+        = page.histories.size
   .breadcrumb= page_breadcrumb_links(page).html_safe
 
 .content

--- a/db/migrate/20151202134702_add_meeting_attendances_count_to_meeting.rb
+++ b/db/migrate/20151202134702_add_meeting_attendances_count_to_meeting.rb
@@ -1,0 +1,5 @@
+class AddMeetingAttendancesCountToMeeting < ActiveRecord::Migration
+  def change
+    add_column :meetings, :meeting_attendances_count, :integer, default: 0
+  end
+end

--- a/db/migrate/20151202135621_reset_meeting_attendances_counter.rb
+++ b/db/migrate/20151202135621_reset_meeting_attendances_counter.rb
@@ -1,0 +1,10 @@
+class ResetMeetingAttendancesCounter < ActiveRecord::Migration
+  def up
+    Meeting.find_each do |meeting|
+      Meeting.reset_counters(meeting.id, :meeting_attendances)
+    end
+  end
+
+  def down
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151202082349) do
+ActiveRecord::Schema.define(version: 20151202135621) do
 
   create_table "api_keys", force: :cascade do |t|
     t.integer  "user_id"
@@ -88,12 +88,13 @@ ActiveRecord::Schema.define(version: 20151202082349) do
 
   create_table "meetings", force: :cascade do |t|
     t.string   "name"
-    t.datetime "start_at",                   null: false
-    t.datetime "end_at",                     null: false
-    t.datetime "created_at",                 null: false
-    t.datetime "updated_at",                 null: false
+    t.datetime "start_at",                                  null: false
+    t.datetime "end_at",                                    null: false
+    t.datetime "created_at",                                null: false
+    t.datetime "updated_at",                                null: false
     t.text     "content"
-    t.boolean  "juried",     default: false, null: false
+    t.boolean  "juried",                    default: false, null: false
+    t.integer  "meeting_attendances_count", default: 0
   end
 
   create_table "page_histories", force: :cascade do |t|


### PR DESCRIPTION
- Meetings#showで何人がPresentation登録をしているか表示する登録をしているか表示する
- タイトルの(仮)を消去
- コメント欄に絵文字の使用を促すPlaceholderを追加
- Meetings#indexの表示高速化のためにMeeting.meeting_attendancesにcounter_cacheを追加
- Meetings#showの表示高速化のためにMeeting.presentationsをeager loading

![2015-12-04 13 03 51](https://cloud.githubusercontent.com/assets/2297122/11581660/ab936a3e-9a87-11e5-8eb8-958c6c3a7af4.png)
![2015-12-04 13 05 28](https://cloud.githubusercontent.com/assets/2297122/11581672/c541e078-9a87-11e5-91fe-ec8761c43afc.png)
