### PR TITLE
評価一覧画面の使い勝手を向上・管理者用の導線設定

### DIFF
--- a/app/controllers/presentations_controller.rb
+++ b/app/controllers/presentations_controller.rb
@@ -4,6 +4,7 @@ class PresentationsController < ApplicationController
   before_action :require_active_current_user
   before_action :set_meeting, only: [:new, :create]
   before_action :set_presentation, only: [:show, :edit, :update, :destroy]
+  before_action :require_accepting, only: [:new, :create]
   before_action :require_ownership, except: [:show, :new, :create]
   before_action :set_emoji_completion, only: [:show]
   before_action :set_user_completion, only: [:show]
@@ -12,13 +13,11 @@ class PresentationsController < ApplicationController
   end
 
   def new
-    return redirect_to meeting_path(@meeting) unless @meeting.accepting?
     @presentation = @meeting.presentations.build
     @presentation.presentation_handouts.build
   end
 
   def create
-    return redirect_to meeting_path(@meeting) unless @meeting.accepting?
     @presentation = @meeting.presentations.build(presentation_params)
     if @presentation.save
       redirect_to meeting_path(@meeting)
@@ -52,6 +51,10 @@ class PresentationsController < ApplicationController
 
   def set_presentation
     @presentation = Presentation.find(params[:id])
+  end
+
+  def require_accepting
+    redirect_to meeting_path(@meeting) unless @meeting.accepting?
   end
 
   def require_ownership

--- a/app/controllers/user_judgments_controller.rb
+++ b/app/controllers/user_judgments_controller.rb
@@ -1,12 +1,12 @@
 class UserJudgmentsController < ApplicationController
   before_action :require_active_current_user
   before_action :require_privilege, only: :index
-  before_action :set_presentation, only: [:index, :create]
+  before_action :set_presentation, only: :create
   before_action :set_user_judgment, only: :destroy
   before_action :require_ownership, only: :destroy
 
   def index
-    @user_judgments = @presentation.user_judgments.includes(:user)
+    @meeting = Meeting.includes(presentations: :user_judgments).find(params[:meeting_id])
   end
 
   def create

--- a/app/views/meetings/_form.html.haml
+++ b/app/views/meetings/_form.html.haml
@@ -10,7 +10,7 @@
   = f.label :juried
   = f.check_box :juried
   = f.label :accepting
-  = f.check_box :accepting, checked: true
+  = f.check_box :accepting, checked: !@meeting.persisted? || @meeting.accepting
   = f.text_area :content, rows: 20, class: 'emoji-complete user-complete'
   = f.submit
   = link_to 'Cancel', cancel_path

--- a/app/views/meetings/_form.html.haml
+++ b/app/views/meetings/_form.html.haml
@@ -10,7 +10,7 @@
   = f.label :juried
   = f.check_box :juried
   = f.label :accepting
-  = f.check_box :accepting, checked: !@meeting.persisted? || @meeting.accepting
+  = f.check_box :accepting, checked: @meeting.new_record? || @meeting.accepting
   = f.text_area :content, rows: 20, class: 'emoji-complete user-complete'
   = f.submit
   = link_to 'Cancel', cancel_path

--- a/app/views/meetings/show.html.haml
+++ b/app/views/meetings/show.html.haml
@@ -43,9 +43,11 @@
                 %i.fa.fa-external-link
         %td= presentation.last_edited_at
   - if @meeting.accepting?
-    = link_to 'プレゼンテーション登録', new_meeting_presentation_path(@meeting)
+    = link_to 'プレゼンテーション登録', new_meeting_presentation_path(@meeting), class: 'button'
   - else
     %p (プレゼンテーション登録は現在締め切られています)
+  - if @meeting.juried? && @current_user.has_privilege?(:user_judgments, :index)
+    = link_to 'プレゼンテーションの評価結果を確認', meeting_user_judgments_path(@meeting)
   - if @current_user.has_privilege?('meetings', 'update')
     .edit_link
       = link_to 'このミーティングを編集', edit_meeting_path(@meeting)

--- a/app/views/settings/edit_profile.html.haml
+++ b/app/views/settings/edit_profile.html.haml
@@ -39,6 +39,7 @@
     %ul
       - @current_user.privileges.each do |privilege|
         %li= privilege.stringify
-    = link_to '他のユーザへの権限共有', new_privilege_path
+    %p= link_to '他のユーザへの権限共有', new_privilege_path
+    %p= link_to '権限を持っているユーザ一覧', privileges_path
   - else
     %p 特別に許可されたアクセス権限はありません

--- a/app/views/user_judgments/index.html.haml
+++ b/app/views/user_judgments/index.html.haml
@@ -11,5 +11,5 @@
       %tr
         %td= presentation.user.nickname
         %td= link_to presentation.title, presentation_path(presentation)
-        %td= user_judgements[true].map { |j| j.user.nickname }.join(', ')
-        %td= user_judgements[false].map { |j| j.user.nickname }.join(', ')
+        %td= user_judgements[true].try(:map) { |j| j.user.nickname }.try(:join, ', ')
+        %td= user_judgements[false].try(:map) { |j| j.user.nickname }.try(:join, ', ')

--- a/app/views/user_judgments/index.html.haml
+++ b/app/views/user_judgments/index.html.haml
@@ -1,17 +1,15 @@
 .content
-  %h1 評価一覧
-  %p
-    発表者:
-    = @presentation.user.nickname
-  %p
-    発表タイトル:
-    = link_to @presentation.title , presentation_path(@presentation)
-  %h2 評価
+  %h1= "#{@meeting.name}のプレゼンテーション評価一覧"
   %table
     %tr
       %th Name
-      %th Judgement
-    - @user_judgments.each do |user_judgment|
+      %th Title
+      %th Pass
+      %th Fail
+    - @meeting.presentations.each do |presentation|
+      - user_judgements = presentation.user_judgments.group_by(&:passed)
       %tr
-        %td= user_judgment.user.nickname
-        %td= user_judgment.stringify
+        %td= presentation.user.nickname
+        %td= link_to presentation.title, presentation_path(presentation)
+        %td= user_judgements[true].map { |j| j.user.nickname }.join(', ')
+        %td= user_judgements[false].map { |j| j.user.nickname }.join(', ')

--- a/app/views/user_judgments/index.html.haml
+++ b/app/views/user_judgments/index.html.haml
@@ -1,5 +1,5 @@
 .content
-  %h1= "#{@meeting.name}のプレゼンテーション評価一覧"
+  %h1 #{@meeting.name}のプレゼンテーション評価一覧
   %table
     %tr
       %th Name

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,8 +10,9 @@ Rails.application.routes.draw do
   resources :groups, only: [:index, :create]
   resources :privileges, only: [:index, :new, :create]
   resources :meetings, except: :destroy, shallow: true do
+    resources :user_judgments, only: :index
     resources :presentations, except: :index, shallow: true do
-      resources :user_judgments, only: [:index, :create, :destroy]
+      resources :user_judgments, only: [:create, :destroy]
     end
   end
   resources :uploads, only: [:index, :create, :show] do

--- a/spec/controllers/user_judgments_controller_spec.rb
+++ b/spec/controllers/user_judgments_controller_spec.rb
@@ -3,11 +3,12 @@ require 'rails_helper'
 RSpec.describe UserJudgmentsController, type: :controller do
   render_views
   let(:user) { FactoryGirl.create(:user) }
+  let(:meeting) { FactoryGirl.create(:meeting) }
   let(:presentation) { FactoryGirl.create(:presentation) }
   before { login_as_user(user) }
 
   describe '#index' do
-    subject { get :index, presentation_id: presentation.id }
+    subject { get :index, meeting_id: meeting.id }
 
     context 'with privilege' do
       before { FactoryGirl.create(:privilege, user: user, model: 'user_judgments', action: 'index') }


### PR DESCRIPTION
評価結果一覧画面を全ユーザでまとめて表示するように変更
![2016-02-03 3 44 18](https://cloud.githubusercontent.com/assets/2297122/12760173/7faaa81c-ca28-11e5-8778-c60432df6eed.png)

評価結果確認用リンクを追加 (権限のある人にだけ見える)
![2016-02-03 3 44 12](https://cloud.githubusercontent.com/assets/2297122/12760218/b12dccac-ca28-11e5-8210-b6de8e64a243.png)

ついでに権限を持ってる人一覧へのリンクも追加
![2016-02-03 3 43 03](https://cloud.githubusercontent.com/assets/2297122/12760251/d22468d0-ca28-11e5-8ab8-e8cbaaad35e5.png)

あと地味にAcceptingをfalseにしててもMeeting#editでデフォルトがtrueになってしまうバグも直した。 (https://github.com/sfc-rg/rg-portal/commit/017c7d292252afb53fe63f850b1198322362e4d6)
