### PR TITLE
プレゼンテーションの順番を決めるコントローラを作成

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -30,6 +30,7 @@
 @import "presentations";
 @import "blogs";
 @import "responsive";
+@import "presentation_orders";
 
 .flash {
   margin: 0 10px 20px;

--- a/app/assets/stylesheets/presentation_orders.scss
+++ b/app/assets/stylesheets/presentation_orders.scss
@@ -1,0 +1,4 @@
+.order-selector {
+  margin: auto;
+  width: 6em;
+}

--- a/app/controllers/presentation_orders_controller.rb
+++ b/app/controllers/presentation_orders_controller.rb
@@ -1,0 +1,47 @@
+class PresentationOrdersController < ApplicationController
+  before_action :require_active_current_user
+  before_action :require_privilege, only: :create
+  before_action :set_meeting
+
+  def index
+  end
+
+  def create
+    Presentation.transaction do
+      orders = Array(1..@meeting.presentations.size)
+      randomize_presentations = []
+      presentation_order_params[:order].each do |presentation_id, order|
+        order = order.to_i
+        presentation = Presentation.find(presentation_id)
+        unless order > 0
+          # delay the determination of randomized order
+          randomize_presentations.push(presentation)
+          next
+        end
+        # update order fixed presentation
+        presentation.update_attributes!(order: order)
+        orders.delete(order)
+      end
+      # update order randomized presentation
+      randomize_presentations.each do |presentation|
+        order = orders.delete_at(rand(orders.size))
+        presentation.update_attributes!(order: order)
+      end
+    end
+    redirect_to meeting_path(@meeting), flash: { success: 'プレゼンテーション順を変更しました' }
+  rescue => e
+    redirect_to meeting_path(@meeting), flash: { error: "プレゼンテーション順の変更に失敗しました\nエラー: #{e.message}" }
+  end
+
+  private
+
+  def set_meeting
+    @meeting = Meeting.find(params[:meeting_id])
+  end
+
+  def presentation_order_params
+    params.require(:presentation_order).tap do |list|
+      list[:order] = params[:order] if params[:order].is_a?(Hash)
+    end
+  end
+end

--- a/app/models/meeting.rb
+++ b/app/models/meeting.rb
@@ -3,7 +3,7 @@ class Meeting < ActiveRecord::Base
   include MarkdownRender
 
   has_many :meeting_attendances, dependent: :destroy
-  has_many :presentations
+  has_many :presentations, -> { order(order: :asc, created_at: :asc) }
 
   validates :name, presence: true
   validates :start_at, presence: true

--- a/app/models/presentation.rb
+++ b/app/models/presentation.rb
@@ -12,6 +12,7 @@ class Presentation < ActiveRecord::Base
   validates :title, presence: true
   validates :user, presence: true
   validates :meeting, presence: true
+  validates :order, numericality: { greater_than: 0 }
 
   def judgment_by(user)
     user_judgments.find_by(user_id: user.id)

--- a/app/views/meetings/show.html.haml
+++ b/app/views/meetings/show.html.haml
@@ -18,6 +18,8 @@
   - if @meeting.content
     = @meeting.render_content.html_safe
   %h2 登録プレゼンテーション一覧
+  - if @current_user.has_privilege?(:presentation_orders, :create)
+    = link_to 'プレゼンテーション順を調整', meeting_presentation_orders_path(@meeting), class: 'button'
   %table
     %tr
       %th Presenter

--- a/app/views/meetings/show.html.haml
+++ b/app/views/meetings/show.html.haml
@@ -22,12 +22,14 @@
     = link_to 'プレゼンテーション順を調整', meeting_presentation_orders_path(@meeting), class: 'button'
   %table
     %tr
+      %th Order
       %th Presenter
       %th Title
       %th Handouts
       %th Last Edited At
     - @meeting.presentations.each do |presentation|
       %tr
+        %td= presentation.order
         %td
           - if presentation.user_id == @current_user.id
             = link_to edit_presentation_path(presentation) do

--- a/app/views/presentation_orders/index.html.haml
+++ b/app/views/presentation_orders/index.html.haml
@@ -1,0 +1,27 @@
+.content
+  .breadcrumb
+    .link= link_to 'ミーティング一覧', meetings_path
+    .link= link_to @meeting.name, meeting_path(@meeting)
+
+  %h1 #{@meeting.name}の発表順を調整
+  - if @meeting.presentations.empty?
+    %p まだこのミーティングにはプレゼンテーション登録がありません
+  - else
+    %p
+      プレゼンテーション登録者数:
+      = @meeting.presentations.size
+    %h2 登録プレゼンテーション一覧
+    = form_tag meeting_presentation_orders_path(@meeting)
+    %table
+      %tr
+        %th Order
+        %th Presenter
+        %th Title
+      - orders = Array(0..@meeting.presentations.size).map { |i| [i == 0 ? 'random' : i, i] }
+      - @meeting.presentations.each do |presentation|
+        %tr
+          %td
+            = select 'presentation_order[order]', presentation.id, orders, {}, class: 'order-selector'
+          %td= presentation.user.nickname
+          %td= presentation.title
+    = submit_tag

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
   resources :groups, only: [:index, :create]
   resources :privileges, only: [:index, :new, :create]
   resources :meetings, except: :destroy, shallow: true do
+    resources :presentation_orders, only: [:index, :create]
     resources :user_judgments, only: :index
     resources :presentations, except: :index, shallow: true do
       resources :user_judgments, only: [:create, :destroy]

--- a/db/migrate/20160204153705_add_order_to_presentation.rb
+++ b/db/migrate/20160204153705_add_order_to_presentation.rb
@@ -1,0 +1,5 @@
+class AddOrderToPresentation < ActiveRecord::Migration
+  def change
+    add_column :presentations, :order, :integer, default: 1, null: false
+  end
+end

--- a/db/migrate/20160204155932_set_presentation_orders_create_privilege_to_users.rb
+++ b/db/migrate/20160204155932_set_presentation_orders_create_privilege_to_users.rb
@@ -1,0 +1,14 @@
+class SetPresentationOrdersCreatePrivilegeToUsers < ActiveRecord::Migration
+  def up
+    Privilege.where(model: :user_judgments, action: :index).each do |p1|
+      p1.user.privileges.each do |p2|
+        if p2.model == 'meetings'
+          p1.user.privileges.create!(model: 'presentation_orders', action: 'create')
+        end
+      end
+    end
+  end
+
+  def down
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160128114700) do
+ActiveRecord::Schema.define(version: 20160204155932) do
 
   create_table "api_keys", force: :cascade do |t|
     t.integer  "user_id"
@@ -149,9 +149,10 @@ ActiveRecord::Schema.define(version: 20160128114700) do
   create_table "presentations", force: :cascade do |t|
     t.integer  "user_id"
     t.integer  "meeting_id"
-    t.string   "title",      null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.string   "title",                  null: false
+    t.datetime "created_at",             null: false
+    t.datetime "updated_at",             null: false
+    t.integer  "order",      default: 1, null: false
   end
 
   add_index "presentations", ["meeting_id"], name: "index_presentations_on_meeting_id"


### PR DESCRIPTION
「プレゼンテーション順を調整」ボタンから調整に入れる
![2016-02-05 1 28 12](https://cloud.githubusercontent.com/assets/2297122/12821695/cc80eff4-cba7-11e5-9143-17b4682988c8.png)

ドロップダウンで順番を選ぶ。randomにすると残っている数字からランダムな順番になる。
![2016-02-05 1 28 23](https://cloud.githubusercontent.com/assets/2297122/12821697/cf0044d2-cba7-11e5-82a7-3c63b16e0031.png)

この操作を行うためにはpresentation_orders#createの権限が必要
