### PR TITLE
Set cookie expiration_date

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: '_rg-team-io_session'
+Rails.application.config.session_store :cookie_store, key: '_rg-team-io_session', expire_after: 1.year


### PR DESCRIPTION
Set cookie expiration date in order not to delete session cookie even after closing browser.

References:
- http://api.rubyonrails.org/classes/ActionDispatch/Session/CookieStore.html
- https://blog.kksg.net/posts/rails-eternal-session